### PR TITLE
PLC-704:Fix No broker issue

### DIFF
--- a/kq/queue.py
+++ b/kq/queue.py
@@ -125,7 +125,8 @@ class Queue(object):
             ssl_cafile=cafile,
             ssl_certfile=certfile,
             ssl_keyfile=keyfile,
-            ssl_crlfile=crlfile
+            ssl_crlfile=crlfile,
+            api_version=(0, 10, 1)
         )
 
     def __repr__(self):


### PR DESCRIPTION
## Issue
Version 1.3.5 of `kafka-python` library (https://github.com/grofers/kq/blob/master/setup.py#L19) only lists certain API versions 0.8.0 to 0.10.1. So unless you explicitly specify api_version to be (0, 10, 1) the client library's attempt to discover the version will cause a NoBrokersAvailable error.

**Reference**:
https://github.com/dpkp/kafka-python/issues/1308#issuecomment-355430042